### PR TITLE
fix(classroom): 已完成章節無法重看被自動跳下一章 (#212)

### DIFF
--- a/js/src/App2/Ended.tsx
+++ b/js/src/App2/Ended.tsx
@@ -22,14 +22,15 @@ type TEndedProps = {
  * 影片播放至結尾時顯示全屏遮罩：
  * - 首次完成（isFinished=false）：中央圓形倒數動畫 + 倒數文字 + 「重看本章」按鈕；
  *   倒數歸零後自動跳轉至 `next_post_url`。
- * - 重看模式（isFinished=true）：關閉倒數與自動跳轉，改顯示「下一章」+「重看本章」
- *   兩顆手動按鈕，避免已完成章節因 DB 內 last_position_seconds 接近結尾而被
- *   初始 seek 推到末端後立刻觸發 ended → 再次被自動跳下一章的循環。
+ * - 重看模式（isFinished=true）：保留中央圓形 PlayIcon 按鈕（點擊跳下一章，無倒數
+ *   環動畫）+ 完成提示文字 + 「重看本章」按鈕，關閉倒數與自動跳轉，避免已完成
+ *   章節因 DB 內 last_position_seconds 接近結尾而被初始 seek 推到末端後立刻觸發
+ *   ended → 再次被自動跳下一章的循環。
  *
  * 注意：原本 Q1=C 雙按鈕（取消 + 重看）設計已因 VidStack ended 狀態的
  * 多個 BUG（播放按鈕消失、拖拉進度條觸發 progress API 把進度條 seek 回片尾）
- * 於 2026-04-20 人工測試後調整為 Q1=B 僅保留「重看本章」。
- * 重看模式下兩顆按鈕是明確的「手動操作」路徑，不會觸發原本 Q1=C 所遇到的
+ * 於 2026-04-20 人工測試後調整為 Q1=B 僅保留「重看本章」。重看模式下的 PlayIcon
+ * 與「重看本章」都是明確的「手動操作」路徑，不會觸發原本 Q1=C 所遇到的
  * 自動 seek 回片尾問題。
  */
 const Ended = ({ next_post_url, onReplay, isFinished = false }: TEndedProps) => {
@@ -86,31 +87,28 @@ const Ended = ({ next_post_url, onReplay, isFinished = false }: TEndedProps) => 
 	if (isFinished) {
 		return (
 			<div className="absolute top-0 left-0 w-full h-full bg-black/50 flex flex-col items-center justify-center z-10">
+				<div
+					className="w-12 h-12 p-2 bg-white/70 rounded-full mb-8 relative cursor-pointer"
+					onClick={(e) => {
+						e.stopPropagation()
+						window.location.href = next_post_url
+					}}
+				>
+					<PlayIcon />
+				</div>
 				<div className="text-white text-base font-thin mb-6">
 					{__('You have finished this chapter.', 'power-course')}
 				</div>
-				<div className="flex flex-col sm:flex-row gap-2 sm:gap-4 w-full sm:w-auto px-4">
-					<button
-						type="button"
-						className="pc-btn pc-btn-primary pc-btn-sm px-0 lg:px-4 w-full lg:w-auto text-xs sm:text-base pc-btn-outline border-solid"
-						onClick={(e) => {
-							e.stopPropagation()
-							onReplay()
-						}}
-					>
-						{__('Replay chapter', 'power-course')}
-					</button>
-					<button
-						type="button"
-						className="pc-btn pc-btn-primary pc-btn-sm px-0 lg:px-4 w-full lg:w-auto text-xs sm:text-base"
-						onClick={(e) => {
-							e.stopPropagation()
-							window.location.href = next_post_url
-						}}
-					>
-						{__('Next chapter', 'power-course')}
-					</button>
-				</div>
+				<button
+					type="button"
+					className="pc-btn pc-btn-primary pc-btn-sm px-0 lg:px-4 w-full lg:w-auto text-xs sm:text-base pc-btn-outline border-solid"
+					onClick={(e) => {
+						e.stopPropagation()
+						onReplay()
+					}}
+				>
+					{__('Replay chapter', 'power-course')}
+				</button>
 			</div>
 		)
 	}

--- a/js/src/App2/Ended.tsx
+++ b/js/src/App2/Ended.tsx
@@ -8,22 +8,31 @@ const COUNTDOWN = 5
 type TEndedProps = {
 	next_post_url: string
 	onReplay: () => void
+	/**
+	 * 章節是否已完成（finished_at 已寫入）。
+	 * true → 重看模式：不倒數、不自動跳下一章，改為手動「下一章 / 重看本章」雙按鈕。
+	 * false → 首次完成：維持原本 5 秒倒數自動跳下一章流程。
+	 */
+	isFinished?: boolean
 }
 
 /**
  * Ended 倒數遮罩元件
  *
  * 影片播放至結尾時顯示全屏遮罩：
- * - 中央顯示圓形倒數動畫與播放圖標
- * - 下方顯示倒數剩餘秒數文字（支援單複數）
- * - 提供「重看本章」出口按鈕（單一按鈕決策 Q1=B，post-test 2026-04-20）
- * - 倒數歸零後自動跳轉至 `next_post_url`
+ * - 首次完成（isFinished=false）：中央圓形倒數動畫 + 倒數文字 + 「重看本章」按鈕；
+ *   倒數歸零後自動跳轉至 `next_post_url`。
+ * - 重看模式（isFinished=true）：關閉倒數與自動跳轉，改顯示「下一章」+「重看本章」
+ *   兩顆手動按鈕，避免已完成章節因 DB 內 last_position_seconds 接近結尾而被
+ *   初始 seek 推到末端後立刻觸發 ended → 再次被自動跳下一章的循環。
  *
  * 注意：原本 Q1=C 雙按鈕（取消 + 重看）設計已因 VidStack ended 狀態的
  * 多個 BUG（播放按鈕消失、拖拉進度條觸發 progress API 把進度條 seek 回片尾）
  * 於 2026-04-20 人工測試後調整為 Q1=B 僅保留「重看本章」。
+ * 重看模式下兩顆按鈕是明確的「手動操作」路徑，不會觸發原本 Q1=C 所遇到的
+ * 自動 seek 回片尾問題。
  */
-const Ended = ({ next_post_url, onReplay }: TEndedProps) => {
+const Ended = ({ next_post_url, onReplay, isFinished = false }: TEndedProps) => {
 	const [countdown, setCountdown] = useState(COUNTDOWN)
 
 	/**
@@ -40,8 +49,11 @@ const Ended = ({ next_post_url, onReplay }: TEndedProps) => {
 	 *
 	 * 只跑一次：掛載後啟動 setInterval 每秒遞減 countdown，卸載時 clearInterval。
 	 * 拆開為獨立 effect 避免依賴 countdown 導致每秒 teardown/setup interval。
+	 *
+	 * 重看模式（isFinished=true）不啟動倒數。
 	 */
 	useEffect(() => {
+		if (isFinished) return
 		if (isCancelledRef.current) return
 
 		const interval = setInterval(() => {
@@ -49,24 +61,61 @@ const Ended = ({ next_post_url, onReplay }: TEndedProps) => {
 		}, 1000)
 
 		return () => clearInterval(interval)
-	}, [])
+	}, [isFinished])
 
 	/**
 	 * Effect B：倒數歸零後跳轉至下一章
 	 *
 	 * 僅在 countdown 變為 0 時觸發一次跳轉，並再次檢查 isCancelledRef 守衛
 	 * 避免使用者在最後一刻按下按鈕後仍被跳轉。
+	 *
+	 * 重看模式（isFinished=true）跳過自動跳轉。
 	 */
 	useEffect(() => {
+		if (isFinished) return
 		if (countdown === 0 && next_post_url && !isCancelledRef.current) {
 			window.location.href = next_post_url
 		}
-	}, [countdown, next_post_url])
+	}, [countdown, next_post_url, isFinished])
 
 	if (!next_post_url) {
 		return null
 	}
 
+	// 重看模式：關閉倒數與自動跳轉，改顯示「下一章 / 重看本章」手動雙按鈕
+	if (isFinished) {
+		return (
+			<div className="absolute top-0 left-0 w-full h-full bg-black/50 flex flex-col items-center justify-center z-10">
+				<div className="text-white text-base font-thin mb-6">
+					{__('You have finished this chapter.', 'power-course')}
+				</div>
+				<div className="flex flex-col sm:flex-row gap-2 sm:gap-4 w-full sm:w-auto px-4">
+					<button
+						type="button"
+						className="pc-btn pc-btn-primary pc-btn-sm px-0 lg:px-4 w-full lg:w-auto text-xs sm:text-base pc-btn-outline border-solid"
+						onClick={(e) => {
+							e.stopPropagation()
+							onReplay()
+						}}
+					>
+						{__('Replay chapter', 'power-course')}
+					</button>
+					<button
+						type="button"
+						className="pc-btn pc-btn-primary pc-btn-sm px-0 lg:px-4 w-full lg:w-auto text-xs sm:text-base"
+						onClick={(e) => {
+							e.stopPropagation()
+							window.location.href = next_post_url
+						}}
+					>
+						{__('Next chapter', 'power-course')}
+					</button>
+				</div>
+			</div>
+		)
+	}
+
+	// 首次完成：維持原本倒數自動跳下一章流程
 	return (
 		<div className="absolute top-0 left-0 w-full h-full bg-black/50 flex flex-col items-center justify-center z-10">
 			<div

--- a/js/src/App2/Player.tsx
+++ b/js/src/App2/Player.tsx
@@ -87,12 +87,21 @@ const Player = ({
 	/** VidStack player ref（必須透過 ref 操作，useMediaRemote 在 context 外無效） */
 	const playerRef = useRef<MediaPlayerInstance>(null)
 
+	/**
+	 * 章節已完成（finished_at 已寫入）旗標。
+	 * 用於：
+	 * 1. 關閉 useChapterProgress 的 GET/POST（不再 seek 到末端、不再覆蓋進度）
+	 * 2. 讓 <Ended> 不進入倒數自動跳下一章流程（使用者在重看模式）
+	 */
+	const isFinishedFlag = is_finished === 'true'
+
 	/** 章節播放進度 hook */
 	const { initialPosition, handleTimeUpdate, handlePause, handleEnded } =
 		useChapterProgress({
 			chapterId: chapter_id,
 			courseId: course_id,
 			videoType: video_type,
+			isFinished: isFinishedFlag,
 		})
 
 	/**
@@ -248,7 +257,11 @@ const Player = ({
 				/>
 
 				{isEnded && (
-					<Ended next_post_url={next_post_url} onReplay={handleReplay} />
+					<Ended
+						next_post_url={next_post_url}
+						onReplay={handleReplay}
+						isFinished={isFinishedFlag}
+					/>
 				)}
 
 				{!isEnded && (

--- a/js/src/App2/hooks/useChapterProgress.ts
+++ b/js/src/App2/hooks/useChapterProgress.ts
@@ -10,6 +10,12 @@ interface UseChapterProgressOptions {
 	chapterId?: string
 	courseId?: string
 	videoType?: string
+	/**
+	 * 章節是否已完成（finished_at 已寫入）。
+	 * 已完成時不再追蹤進度 — 不 GET 上次位置（避免 seek 到末端觸發 ended 循環）、
+	 * 不 POST 新進度（保留 DB 原值讓使用者後續回到「繼續觀看」時仍有參考點）。
+	 */
+	isFinished?: boolean
 }
 
 interface UseChapterProgressResult {
@@ -38,15 +44,24 @@ export function useChapterProgress({
 	chapterId,
 	courseId: _courseId,
 	videoType,
+	isFinished = false,
 }: UseChapterProgressOptions): UseChapterProgressResult {
 	const [initialPosition, setInitialPosition] = useState<number>(0)
 	const [isLoadingPosition, setIsLoadingPosition] = useState<boolean>(false)
 
-	/** 是否應該追蹤此影片類型 */
+	/**
+	 * 是否應該追蹤此影片類型
+	 *
+	 * isFinished=true 時一律關閉追蹤，避免：
+	 * (A) GET 拉到接近影片結尾的 last_position_seconds，
+	 *     被 Player 初始 seek 帶到末端而立刻觸發 onEnded → 自動跳下一章。
+	 * (B) 重看過程的 time_update / pause / ended 覆蓋掉 DB 值。
+	 */
 	const shouldTrack = Boolean(
 		chapterId &&
 			videoType &&
-			TRACKED_VIDEO_TYPES.includes(videoType),
+			TRACKED_VIDEO_TYPES.includes(videoType) &&
+			!isFinished,
 	)
 
 	/** 最後一次 POST 的時間戳（用於 throttle） */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "power-course",
 	"private": true,
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"author": "J7 <j7.dev.gg@gmail.com>",
 	"type": "module",
 	"scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Power Course | WordPress 最好用的課程外掛
  * Plugin URI:        https://github.com/zenbuapps/wp-power-course
  * Description:       WordPress 最好用的課程外掛
- * Version:           1.2.5
+ * Version:           1.2.6
  * Requires at least: 5.7
  * Requires PHP:      8.0
  * Author:            J7


### PR DESCRIPTION
## Summary

修復使用者回報的「已完成章節無法重看，會被 5 秒倒數自動帶到下一章」BUG。

詳細根因分析見 Issue #212。本 PR 採方向 A（最小前端修改），不動 DB schema、不動 REST API contract。

## Changes

- **`js/src/App2/hooks/useChapterProgress.ts`** — 新增 `isFinished?: boolean` 參數。`isFinished === true` 時 `shouldTrack = false`，跳過初始 GET 與所有 POST（throttle / pause / ended / beforeunload beacon）。
- **`js/src/App2/Player.tsx`** — 依 `is_finished === 'true'` 推得 `isFinishedFlag`，傳入 `useChapterProgress` 與 `<Ended>`。
- **`js/src/App2/Ended.tsx`** — 新增 `isFinished?: boolean` prop。`true` 時關閉倒數與自動跳轉，保留中央圓形 PlayIcon（點擊 → 下一章，無倒數環動畫）+ 完成提示文字 + 「重看本章」按鈕，視覺與首次完成流程一致，只移除 5 秒倒數。
- **`package.json` + `plugin.php`** — 版本 bump 至 `1.2.6`。

## 行為差異

| 情境 | 舊 (v1.2.5) | 新 (v1.2.6) |
|---|---|---|
| 首次完成章節 | 95% 觸發 finish API → 影片結束後 5 秒倒數自動跳下一章 | **不變** |
| 重新開啟已完成章節 | 初始 seek 到末端 → 影片瞬間結束 → 5 秒倒數自動跳下一章 | 從 0 秒播放，可完整重看；無任何遮罩或倒數 |
| 重看過程 time update | 每 30s POST 進度，覆蓋 DB | 不再 POST，保留 DB 舊值（或 0） |
| 重看至結尾 | 5 秒倒數自動跳下一章 | `<Ended>` 顯示 PlayIcon（→ 下一章）+「重看本章」按鈕，無倒數、不自動跳 |

## 資料修補

舊 DB 資料（已完成章節 `last_position_seconds` 接近末端）在 hook 不再 GET 後自動失效，不需 migration。若需立即清理，可跑 Issue #212 內附的 SQL。

## 線上 Hot-Fix 紀錄（moobaker.com，2026-04-22）

本 PR 尚未 release 前，回報站 `moobaker.com` 已先套用**純後端 hot-fix**（不碰 JS，不需 rebuild dist）。**與本 PR 的方向 A 實作方式不同**，部署 v1.2.6 時需還原或直接覆蓋 plugin 目錄。

### Hot-fix 內容

1. **DB 清零**：已完成章節的 `last_position_seconds` UPDATE 為 0（45 筆）。備份至 `qeqIB_pc_chapter_progress_bak_20260422`。
2. **`inc/templates/pages/classroom/body.php`**：新增 `if ( $is_finished_for_video ) { $next_post_url = ''; }`。利用既有 `<Ended>` 元件中 `if (!next_post_url) return null` 的早退路徑，讓已完成章節**整個遮罩不渲染**。
3. **`inc/classes/Resources/ChapterProgress/Core/Api.php`**：POST `/chapters/{id}/progress` 在章節已 `finished_at` 時提前返回 `written: false, reason: chapter_already_finished`，不呼叫 `upsert_progress`。

### Hot-fix vs 本 PR 的 UX 差異

| 情境 | moobaker.com hot-fix | 本 PR (v1.2.6) |
|---|---|---|
| 重看至結尾 | `<Ended>` 遮罩**完全不出現**（next_post_url 空 → early return null）| `<Ended>` 顯示 PlayIcon（→ 下一章）+「重看本章」按鈕 |
| 要切下一章 | 只能靠左側 sidebar | 可點遮罩中央的 PlayIcon 或用 sidebar |

### Hot-fix 檔案備份（moobaker.com 伺服器）

- `/root/patches/moobaker-powercourse-rewatch-20260422/body.php.bak`
- `/root/patches/moobaker-powercourse-rewatch-20260422/Api.php.bak`
- DB 備份表：`qeqIB_pc_chapter_progress_bak_20260422`

### 部署 v1.2.6 到 moobaker.com 時的處置

直接覆蓋整個 `wp-content/plugins/power-course/` 目錄即可，hot-fix 會被正式版本取代。DB 清零的結果不影響新版（新版 hook 本來就不 GET 已完成章節的進度）。

## Test plan

- [ ] 本地 `pnpm install && pnpm build`，無 TS error、vite build 成功。
- [ ] 人工驗證首次完成章節流程不變（95% finish + 結束後 5 秒倒數跳下一章）。
- [ ] 人工驗證已完成章節重新開啟 → 從 0 秒播放，無遮罩。
- [ ] 人工驗證已完成章節完整播放至結尾 → `<Ended>` 顯示中央 PlayIcon（→ 下一章）+「重看本章」按鈕，無倒數、不自動跳。
- [ ] DevTools Network 驗證已完成章節進入時**沒有** `GET /chapters/{id}/progress`，播放中**沒有** `POST /chapters/{id}/progress`。
- [ ] 字幕 / 浮水印 / 管理員預覽模式等其他功能無 regression。
- [ ] 部署 v1.2.6 到 moobaker.com 時覆蓋整個 plugin 目錄（抹除 hot-fix），線上行為切回本 PR 的 `<Ended>` UX。

Closes #212